### PR TITLE
Convert boost hists to ROOT TGraphs

### DIFF
--- a/dijet/scripts/convert_to_root.py
+++ b/dijet/scripts/convert_to_root.py
@@ -20,19 +20,19 @@ import pickle
 import ROOT
 
 # Filter sys.path to remove Python 3.9 specific paths
-# Conflicts of 3.9 to 3.6. 
+# Conflicts of 3.9 to 3.6.
 # Second option is to sort sys.path and move paths from 3.9 to bottom
 sys.path = [p for p in sys.path if "python3.9" not in p]
 
 # Set up argument parser
-parser = argparse.ArgumentParser(description='Read a pickle file with JERs and convert them to root objects.')
-parser.add_argument('--config', default='config_2017', help='Configuration name (default: config_2017)')
-parser.add_argument('--shift', default='nominal', help='Shift type (default: nominal)')
-parser.add_argument('--uncertainty', default='skip_jecunc', help='Uncertainty type (default: skip_jecunc)')
-parser.add_argument('--selector', default='default', help='Selector type (default: default)')
-parser.add_argument('--producer', default='default', help='Producer type (default: default)')
-parser.add_argument('--version', required=True, help='Version, must be specified.')
-parser.add_argument('--sample', required=True, help='Sample name, must be specified.')
+parser = argparse.ArgumentParser(description="Read a pickle file with JERs and convert them to root objects.")
+parser.add_argument("--config", default="config_2017", help="Configuration name (default: config_2017)")
+parser.add_argument("--shift", default="nominal", help="Shift type (default: nominal)")
+parser.add_argument("--uncertainty", default="skip_jecunc", help="Uncertainty type (default: skip_jecunc)")
+parser.add_argument("--selector", default="default", help="Selector type (default: default)")
+parser.add_argument("--producer", default="default", help="Producer type (default: default)")
+parser.add_argument("--version", required=True, help="Version, must be specified.")
+parser.add_argument("--sample", required=True, help="Sample name, must be specified.")
 
 # Parse the command-line arguments
 args = parser.parse_args()
@@ -61,7 +61,7 @@ if not os.path.exists(full_path):
     raise Exception(f"The file {full_path} does not exist.")
 
 # Load and display the contents of the pickle file
-with open(full_path, 'rb') as file:
+with open(full_path, "rb") as file:
     data = pickle.load(file)
 
 # Store root file in output directory from analysis
@@ -72,16 +72,14 @@ os.makedirs(os.path.dirname(root_path), exist_ok=True)
 root_file = ROOT.TFile(root_path, "RECREATE")
 
 for key, value in data.items():
-    # Extract data for TGraphAsymmErrors
-    # mask = value['fX'].nonzero()
-    n = len(value['fX'])
-    x = value['fX']
-    y = value['fY']
-    xerrup = value['fXerrUp']
-    xerrdown = value['fXerrDown']
-    yerrup = value['fYerrUp']
-    yerrdown = value['fYerrDown']
-    
+    n = len(value["fX"])
+    x = value["fX"]
+    y = value["fY"]
+    xerrup = value["fXerrUp"]
+    xerrdown = value["fXerrDown"]
+    yerrup = value["fYerrUp"]
+    yerrdown = value["fYerrDown"]
+
     # Create TGraphAsymmErrors object
     graph = ROOT.TGraphAsymmErrors(n, y, x, yerrdown, yerrup, xerrdown, xerrup)
 

--- a/dijet/scripts/convert_to_root.py
+++ b/dijet/scripts/convert_to_root.py
@@ -42,17 +42,18 @@ for arg in vars(args):
     print(f"{arg}: {getattr(args, arg)}")
 
 # Construct the file path
-base_path = "/nfs/dust/cms/user/paaschal/WorkingArea/Analysis/JERC/DiJet/data/dijet_store/analysis_dijet/"
+base_path = os.getenv("CF_STORE_LOCAL")
 full_path = os.path.join(
     base_path,
-    "dijet.JERtoRoot/",
-    f"{args.config}/",
-    f"{args.shift}/",
-    f"calib__{args.uncertainty}/",
+    "analysis_dijet",
+    "dijet.JERtoRoot",
+    f"{args.config}",
+    f"{args.shift}",
+    f"calib__{args.uncertainty}",
     f"sel__{args.selector}",
-    f"prod__{args.producer}/",
-    f"{args.version}/",
-    f"{args.sample}/",
+    f"prod__{args.producer}",
+    f"{args.version}",
+    f"{args.sample}",
     "jers.pickle",
 )
 

--- a/dijet/scripts/convert_to_root.py
+++ b/dijet/scripts/convert_to_root.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python3.6
+# coding: utf-8
+
+"""
+Script to convert output of dijet.JERtoRoot to a TGraphAsymError.
+Keep eye on uprrot PR https://github.com/scikit-hep/uproot5/pull/1144
+to directly implement it in the task itself.
+
+Root is not in Sandboxes from CF.
+Needs to be run with python 3.6 isntead.
+
+Structure of arguments is based on CF output. Run via
+./convert_to_root.py --version <v> --sample <dataset> --<option> <arg> ...
+"""
+
+import sys
+import argparse
+import os
+import pickle
+import ROOT
+
+# Filter sys.path to remove Python 3.9 specific paths
+# Conflicts of 3.9 to 3.6. 
+# Second option is to sort sys.path and move paths from 3.9 to bottom
+sys.path = [p for p in sys.path if "python3.9" not in p]
+
+# Set up argument parser
+parser = argparse.ArgumentParser(description='Read a pickle file with JERs and convert them to root objects.')
+parser.add_argument('--config', default='config_2017', help='Configuration name (default: config_2017)')
+parser.add_argument('--shift', default='nominal', help='Shift type (default: nominal)')
+parser.add_argument('--uncertainty', default='skip_jecunc', help='Uncertainty type (default: skip_jecunc)')
+parser.add_argument('--selector', default='default', help='Selector type (default: default)')
+parser.add_argument('--producer', default='default', help='Producer type (default: default)')
+parser.add_argument('--version', required=True, help='Version, must be specified.')
+parser.add_argument('--sample', required=True, help='Sample name, must be specified.')
+
+# Parse the command-line arguments
+args = parser.parse_args()
+
+# Print all options and the arguments given
+for arg in vars(args):
+    print(f"{arg}: {getattr(args, arg)}")
+
+# Construct the file path
+base_path = "/nfs/dust/cms/user/paaschal/WorkingArea/Analysis/JERC/DiJet/data/dijet_store/analysis_dijet/"
+full_path = os.path.join(
+    base_path,
+    "dijet.JERtoRoot/",
+    f"{args.config}/",
+    f"{args.shift}/",
+    f"calib__{args.uncertainty}/",
+    f"sel__{args.selector}",
+    f"prod__{args.producer}/",
+    f"{args.version}/",
+    f"{args.sample}/",
+    "jers.pickle",
+)
+
+# Check if the file exists
+if not os.path.exists(full_path):
+    raise Exception(f"The file {full_path} does not exist.")
+
+# Load and display the contents of the pickle file
+with open(full_path, 'rb') as file:
+    data = pickle.load(file)
+
+# Store root file in output directory from analysis
+root_path = full_path.replace("dijet.JERtoRoot", "rootfiles").replace(".pickle", ".root")
+
+# Ensure the directory exists
+os.makedirs(os.path.dirname(root_path), exist_ok=True)
+root_file = ROOT.TFile(root_path, "RECREATE")
+
+for key, value in data.items():
+    # Extract data for TGraphAsymmErrors
+    # mask = value['fX'].nonzero()
+    n = len(value['fX'])
+    x = value['fX']
+    y = value['fY']
+    xerrup = value['fXerrUp']
+    xerrdown = value['fXerrDown']
+    yerrup = value['fYerrUp']
+    yerrdown = value['fYerrDown']
+    
+    # Create TGraphAsymmErrors object
+    graph = ROOT.TGraphAsymmErrors(n, y, x, yerrdown, yerrup, xerrdown, xerrup)
+
+root_file.Close()
+print(f"All TGraphAsymmErrors objects have been stored in {root_path}")

--- a/dijet/scripts/convert_to_root.py
+++ b/dijet/scripts/convert_to_root.py
@@ -7,7 +7,7 @@ Keep eye on uprrot PR https://github.com/scikit-hep/uproot5/pull/1144
 to directly implement it in the task itself.
 
 Root is not in Sandboxes from CF.
-Needs to be run with python 3.6 isntead.
+Needs to be run with python 3.6 instead.
 
 Structure of arguments is based on CF output. Run via
 ./convert_to_root.py --version <v> --sample <dataset> --<option> <arg> ...
@@ -28,7 +28,7 @@ sys.path = [p for p in sys.path if "python3.9" not in p]
 parser = argparse.ArgumentParser(description="Read a pickle file with JERs and convert them to root objects.")
 parser.add_argument("--config", default="config_2017", help="Configuration name (default: config_2017)")
 parser.add_argument("--shift", default="nominal", help="Shift type (default: nominal)")
-parser.add_argument("--uncertainty", default="skip_jecunc", help="Uncertainty type (default: skip_jecunc)")
+parser.add_argument("--calibrator", default="skip_jecunc", help="Calibrator type (default: skip_jecunc)")
 parser.add_argument("--selector", default="default", help="Selector type (default: default)")
 parser.add_argument("--producer", default="default", help="Producer type (default: default)")
 parser.add_argument("--version", required=True, help="Version, must be specified.")
@@ -49,7 +49,7 @@ full_path = os.path.join(
     "dijet.JERtoRoot",
     f"{args.config}",
     f"{args.shift}",
-    f"calib__{args.uncertainty}",
+    f"calib__{args.calibrator}",
     f"sel__{args.selector}",
     f"prod__{args.producer}",
     f"{args.version}",

--- a/dijet/tasks/base.py
+++ b/dijet/tasks/base.py
@@ -41,6 +41,9 @@ class HistogramsBaseTask(
     # Add nested sibling directories to output path
     output_collection_cls = law.NestedSiblingFileCollection
 
+    # Category ID for methods
+    category_id = {"sm": 1, "fe": 2}
+
     def get_datasets(self) -> tuple[list[str], bool]:
         """
         Select datasets belonging to the `process` of the current branch task.

--- a/dijet/tasks/base.py
+++ b/dijet/tasks/base.py
@@ -42,7 +42,7 @@ class HistogramsBaseTask(
     output_collection_cls = law.NestedSiblingFileCollection
 
     # Category ID for methods
-    category_id = {"sm": 1, "fe": 2}
+    LOOKUP_CATEGORY_ID = {"sm": 1, "fe": 2}
 
     def get_datasets(self) -> tuple[list[str], bool]:
         """

--- a/dijet/tasks/base.py
+++ b/dijet/tasks/base.py
@@ -60,7 +60,7 @@ class HistogramsBaseTask(
         # check that at least one config dataset matched
         if not dataset_insts_from_process:
             raise RuntimeError(
-                "no single dataset found in config matching ",
+                "no single dataset found in config matching "
                 f"process `{self.branch_data.process}`",
             )
 
@@ -71,7 +71,7 @@ class HistogramsBaseTask(
         # check that at least one user-supplied dataset matched
         if not datasets_filtered:
             raise RuntimeError(
-                "no single user-supplied dataset matched ",
+                "no single user-supplied dataset matched "
                 f"process `{self.branch_data.process}`",
             )
 

--- a/dijet/tasks/base.py
+++ b/dijet/tasks/base.py
@@ -60,8 +60,8 @@ class HistogramsBaseTask(
         # check that at least one config dataset matched
         if not dataset_insts_from_process:
             raise RuntimeError(
-                "no single dataset found in config matching "
-                f"process `{self.branch_data.process}`"
+                "no single dataset found in config matching ",
+                f"process `{self.branch_data.process}`",
             )
 
         # filter to contain only user-supplied datasets
@@ -71,8 +71,8 @@ class HistogramsBaseTask(
         # check that at least one user-supplied dataset matched
         if not datasets_filtered:
             raise RuntimeError(
-                "no single user-supplied dataset matched "
-                f"process `{self.branch_data.process}`"
+                "no single user-supplied dataset matched ",
+                f"process `{self.branch_data.process}`",
             )
 
         # set MC flag if any of the filtered datasets
@@ -82,7 +82,7 @@ class HistogramsBaseTask(
         )
         if len(datasets_filtered_is_mc) > 1:
             raise RuntimeError(
-                "filtered datasets have mismatched `is_mc` flags"
+                "filtered datasets have mismatched `is_mc` flags",
             )
 
         # return filtered datasets and is_mc flag

--- a/dijet/tasks/jer.py
+++ b/dijet/tasks/jer.py
@@ -68,9 +68,8 @@ class JER(HistogramsBaseTask):
 
         # get index on `category` axis corresponding to
         # the two computation methods
-        category_id = {"sm": 1, "fe": 2}
         categories = list(h_widths.axes["category"])
-        index_methods = {m: categories.index(category_id[m]) for m in category_id}
+        index_methods = {m: categories.index(self.category_id[m]) for m in self.category_id}
 
         # calcuate JER for standard method
         jer_sm_val = h_widths[index_methods["sm"], :, :].values() * np.sqrt(2)

--- a/dijet/tasks/jer.py
+++ b/dijet/tasks/jer.py
@@ -94,10 +94,10 @@ class JER(HistogramsBaseTask):
         v_jer = h_jer.view()
 
         # write JER values to output histogram
-        v_jer[index_methods["sm"], :, :].value = jer_sm_val
-        v_jer[index_methods["sm"], :, :].variance = jer_sm_err**2
-        v_jer[index_methods["fe"], :, :].value = jer_fe_val
-        v_jer[index_methods["fe"], :, :].variance = jer_fe_err**2
+        v_jer[index_methods["sm"], :, :].value = np.nan_to_num(jer_sm_val)
+        v_jer[index_methods["sm"], :, :].variance = np.nan_to_num(jer_sm_err**2)
+        v_jer[index_methods["fe"], :, :].value = np.nan_to_num(jer_fe_val)
+        v_jer[index_methods["fe"], :, :].variance = np.nan_to_num(jer_fe_err**2)
 
         results_jers = {
             "jer": h_jer,

--- a/dijet/tasks/jer.py
+++ b/dijet/tasks/jer.py
@@ -69,7 +69,7 @@ class JER(HistogramsBaseTask):
         # get index on `category` axis corresponding to
         # the two computation methods
         categories = list(h_widths.axes["category"])
-        index_methods = {m: categories.index(self.category_id[m]) for m in self.category_id}
+        index_methods = {m: categories.index(self.LOOKUP_CATEGORY_ID[m]) for m in self.LOOKUP_CATEGORY_ID}
 
         # calcuate JER for standard method
         jer_sm_val = h_widths[index_methods["sm"], :, :].values() * np.sqrt(2)
@@ -93,10 +93,10 @@ class JER(HistogramsBaseTask):
         v_jer = h_jer.view()
 
         # write JER values to output histogram
-        v_jer[index_methods["sm"], :, :].value = np.nan_to_num(jer_sm_val)
-        v_jer[index_methods["sm"], :, :].variance = np.nan_to_num(jer_sm_err**2)
-        v_jer[index_methods["fe"], :, :].value = np.nan_to_num(jer_fe_val)
-        v_jer[index_methods["fe"], :, :].variance = np.nan_to_num(jer_fe_err**2)
+        v_jer[index_methods["sm"], :, :].value = np.nan_to_num(jer_sm_val, nan=0.0)
+        v_jer[index_methods["sm"], :, :].variance = np.nan_to_num(jer_sm_err**2, nan=0.0)
+        v_jer[index_methods["fe"], :, :].value = np.nan_to_num(jer_fe_val, nan=0.0)
+        v_jer[index_methods["fe"], :, :].variance = np.nan_to_num(jer_fe_err**2, nan=0.0)
 
         results_jers = {
             "jer": h_jer,

--- a/dijet/tasks/root.py
+++ b/dijet/tasks/root.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+
+import law
+
+from dijet.tasks.base import HistogramsBaseTask
+from columnflow.util import maybe_import, import_ROOT
+from columnflow.tasks.framework.base import Requirements
+
+from dijet.tasks.jer import JER
+
+ak = maybe_import("awkward")
+hist = maybe_import("hist")
+np = maybe_import("numpy")
+plt = maybe_import("matplotlib.pyplot")
+mplhep = maybe_import("mplhep")
+it = maybe_import("itertools")
+up = maybe_import("uproot")
+
+
+class JERtoRoot(HistogramsBaseTask):
+    """
+    Task to convert JER output to rootfiles.
+    It is not yet possible to write TGraphs via uproot.
+    Efforts by the uproot Team ongoing. Related PR:
+    https://github.com/scikit-hep/uproot5/pull/1144
+    """
+
+    output_collection_cls = law.NestedSiblingFileCollection
+
+    # upstream requirements
+    reqs = Requirements(
+        JER=JER,
+    )
+
+    # TODO: write base task for root conversion
+    #       keep HistogramBaseTask as long as no conversion possible
+    def requires(self):
+        return self.reqs.JER.req(
+            self,
+            branch=-1,
+            _exclude={"branches"},
+        )
+
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+        reqs["key"] = self.as_branch().requires()
+        return reqs
+
+    def load_jer(self):
+        histogram = self.input().collection[0]["jers"].load(formatter="pickle")
+        return histogram
+
+    def output(self) -> dict[law.FileSystemTarget]:
+        sample = self.extract_sample()
+        target = self.target(f"{sample}", dir=True)
+        outp = {
+            "jers": target.child("jers.pickle", type="f"),
+        }
+        return outp
+
+    def run(self):
+        results_jer = self.load_jer()
+        jer = results_jer["jer"]
+
+        eta_bins = jer.axes["probejet_abseta"].edges
+        eta_centers = jer.axes["probejet_abseta"].centers
+
+        # Get error for pt bins. These will be symmetrical for the moment
+        # TODO: Define pt value by the mean value of the pt in given a pt bin
+        pt_bins = jer.axes["dijets_pt_avg"].edges
+        pt_centers = jer.axes["dijets_pt_avg"].centers
+        pt_error_low = pt_centers - pt_bins[:-1]
+        pt_error_high = pt_bins[1:] - pt_centers
+
+        def get_eta_bins(self, i: int):
+            up = "{:.3f}".format(eta_bins[i])
+            do = "{:.3f}".format(eta_bins[i+1])
+            bin_low = up.replace(".","p")
+            bin_high = do.replace(".","p")
+            return bin_low, bin_high
+
+        # Store values for TGraphAsymmError in dictionary and convert with additional script.
+        results_jers = {}
+        for m in self.category_id:
+            for i in range(len(eta_bins)-1):
+                low, high = get_eta_bins(self, i)
+                tmp = jer[
+                    {
+                        "category": hist.loc(self.category_id[m]),
+                        "probejet_abseta": i,
+                    }
+                ]
+                jers = tmp.values()
+                jers_errors = tmp.variances()
+                assert len(jers)==len(pt_centers), f"Check number of bins for {i}"
+                results_jers[f"jer_eta_{low}_{high}_{m}"] = {
+                    "fY": jers,
+                    "fYerrUp": jers_errors,
+                    "fYerrDown": jers_errors,
+                    "fX": pt_centers,
+                    "fXerrUp": pt_error_high,
+                    "fXerrDown": pt_error_low,
+                }
+
+        self.output()["jers"].dump(results_jers, formatter="pickle")

--- a/dijet/tasks/root.py
+++ b/dijet/tasks/root.py
@@ -71,7 +71,7 @@ class JERtoRoot(HistogramsBaseTask):
                 abseta_bins[:-1],
                 abseta_bins[1:],
             ):
-                 
+
                 abseta_lo_str = f"{abseta_lo:.3f}".replace(".", "p")
                 abseta_hi_str = f"{abseta_hi:.3f}".replace(".", "p")
                 abseta_str = f"abseta_{abseta_lo_str}_{abseta_hi_str}"

--- a/dijet/tasks/root.py
+++ b/dijet/tasks/root.py
@@ -3,7 +3,7 @@
 import law
 
 from dijet.tasks.base import HistogramsBaseTask
-from columnflow.util import maybe_import, import_ROOT
+from columnflow.util import maybe_import
 from columnflow.tasks.framework.base import Requirements
 
 from dijet.tasks.jer import JER
@@ -63,7 +63,6 @@ class JERtoRoot(HistogramsBaseTask):
         jer = results_jer["jer"]
 
         eta_bins = jer.axes["probejet_abseta"].edges
-        eta_centers = jer.axes["probejet_abseta"].centers
 
         # Get error for pt bins. These will be symmetrical for the moment
         # TODO: Define pt value by the mean value of the pt in given a pt bin
@@ -74,15 +73,15 @@ class JERtoRoot(HistogramsBaseTask):
 
         def get_eta_bins(self, i: int):
             up = "{:.3f}".format(eta_bins[i])
-            do = "{:.3f}".format(eta_bins[i+1])
-            bin_low = up.replace(".","p")
-            bin_high = do.replace(".","p")
+            do = "{:.3f}".format(eta_bins[i + 1])
+            bin_low = up.replace(".", "p")
+            bin_high = do.replace(".", "p")
             return bin_low, bin_high
 
         # Store values for TGraphAsymmError in dictionary and convert with additional script.
         results_jers = {}
         for m in self.category_id:
-            for i in range(len(eta_bins)-1):
+            for i in range(len(eta_bins) - 1):
                 low, high = get_eta_bins(self, i)
                 tmp = jer[
                     {
@@ -92,7 +91,7 @@ class JERtoRoot(HistogramsBaseTask):
                 ]
                 jers = tmp.values()
                 jers_errors = tmp.variances()
-                assert len(jers)==len(pt_centers), f"Check number of bins for {i}"
+                assert len(jers) == len(pt_centers), f"Check number of bins for {i}"
                 results_jers[f"jer_eta_{low}_{high}_{m}"] = {
                     "fY": jers,
                     "fYerrUp": jers_errors,

--- a/law.cfg
+++ b/law.cfg
@@ -8,7 +8,7 @@ inherit: $CF_BASE/law.cfg
 
 columnflow.tasks.cms.inference
 columnflow.tasks.cms.external
-dijet.tasks.{alpha,jer}
+dijet.tasks.{alpha,jer,root}
 
 
 [logging]
@@ -101,6 +101,8 @@ cf.PlotShiftedVariables: local
 
 dijet.AlphaExtrapolation: local
 dijet.JER: local
+
+dijet.JERtoRoot: local
 
 
 [job]


### PR DESCRIPTION
Task structure to store boost histogram objects as TGraphAsymmErrors in rootfiles.
Main goal is to do this indepently from Root using uproot. 
This is not yet possible but there is ongoing work from the uproot team addressing this issue. 
Updates can be followed in this [PR from uproot5.](https://github.com/scikit-hep/uproot5/pull/1144)

As long as this feature is not yet implement the conversion is done in two steps:
1. Extract values from the boost histogram and store as arrays, which can be used as an input for a TGraph object. Store the dictionary as a pickel file.
2. Extract the arrays from the pickle file and use them as input for a TGraphAsymmError. This step is done independently from CF, since no Root module is implemented in the Sandboxes.

In the long term, the second step is included in the first one and remove the dependency from Root.

Additional
- Move category IDs to base task