### PR TITLE
Set branch in requirements

### DIFF
--- a/dijet/plotting/alpha.py
+++ b/dijet/plotting/alpha.py
@@ -93,8 +93,8 @@ class PlotWidth(
         plt.scatter(wmax, widths["da"], marker="o", color=self.colors["da"], label="Data")
 
         x = np.linspace(0, wmax[-1], 100)
-        fit_mc = inters["mc"] * x + slopes["mc"]
-        fit_da = inters["da"] * x + slopes["da"]
+        fit_mc = slopes["mc"] * x + inters["mc"]
+        fit_da = slopes["da"] * x + inters["da"]
         plt.plot(x, fit_mc, color=self.colors["mc"], linestyle="dashed", linewidth=2)
         plt.plot(x, fit_da, color=self.colors["da"], linestyle="dashed", linewidth=2)
 

--- a/dijet/plotting/alpha.py
+++ b/dijet/plotting/alpha.py
@@ -56,7 +56,7 @@ class PlotWidth(
         return self.reqs.AlphaExtrapolation.req(
             self,
             processes=("qcd", "data"),
-            _exclude={"branches"},
+            branch=-1,
         )
 
     def load_widths(self):

--- a/dijet/plotting/alpha.py
+++ b/dijet/plotting/alpha.py
@@ -5,6 +5,7 @@ import law
 # from dijet.tasks.base import HistogramsBaseTask
 from columnflow.util import maybe_import, DotDict
 from columnflow.tasks.framework.base import Requirements
+from columnflow.tasks.framework.remote import RemoteWorkflow
 
 from dijet.tasks.alpha import AlphaExtrapolation
 from dijet.constants import eta
@@ -20,6 +21,7 @@ mplhep = maybe_import("mplhep")
 class PlotWidth(
     PlottingBaseTask,
     law.LocalWorkflow,
+    RemoteWorkflow,
 ):
     """
     Task to plot all alphas.
@@ -30,6 +32,7 @@ class PlotWidth(
 
     # upstream requirements
     reqs = Requirements(
+        RemoteWorkflow.reqs,
         AlphaExtrapolation=AlphaExtrapolation,
     )
 
@@ -53,7 +56,7 @@ class PlotWidth(
         return self.reqs.AlphaExtrapolation.req(
             self,
             processes=("qcd", "data"),
-            branch=-1,
+            _exclude={"branches"},
         )
 
     def load_widths(self):

--- a/dijet/plotting/asymmetry.py
+++ b/dijet/plotting/asymmetry.py
@@ -5,6 +5,7 @@ import law
 # from dijet.tasks.base import HistogramsBaseTask
 from columnflow.util import maybe_import, DotDict
 from columnflow.tasks.framework.base import Requirements
+from columnflow.tasks.framework.remote import RemoteWorkflow
 
 from dijet.tasks.alpha import AlphaExtrapolation
 from dijet.constants import eta
@@ -20,6 +21,7 @@ mplhep = maybe_import("mplhep")
 class PlotAsymmetries(
     PlottingBaseTask,
     law.LocalWorkflow,
+    RemoteWorkflow,
 ):
     """
     Task to plot all asymmetries.
@@ -30,6 +32,7 @@ class PlotAsymmetries(
 
     # upstream requirements
     reqs = Requirements(
+        RemoteWorkflow.reqs,
         AlphaExtrapolation=AlphaExtrapolation,
     )
 
@@ -48,7 +51,7 @@ class PlotAsymmetries(
         return self.reqs.AlphaExtrapolation.req(
             self,
             processes=("qcd", "data"),
-            branch=-1,
+            _exclude={"branches"},
         )
 
     def load_asymmetry(self):

--- a/dijet/plotting/asymmetry.py
+++ b/dijet/plotting/asymmetry.py
@@ -51,7 +51,7 @@ class PlotAsymmetries(
         return self.reqs.AlphaExtrapolation.req(
             self,
             processes=("qcd", "data"),
-            _exclude={"branches"},
+            branch=-1
         )
 
     def load_asymmetry(self):

--- a/dijet/plotting/jer.py
+++ b/dijet/plotting/jer.py
@@ -37,7 +37,7 @@ class PlotJERs(PlottingBaseTask):
         return self.reqs.JER.req(
             self,
             processes=("qcd", "data"),
-            branch=-1,
+            _exclude={"branches"},
         )
 
     def load_jers(self):

--- a/dijet/tasks/alpha.py
+++ b/dijet/tasks/alpha.py
@@ -156,9 +156,9 @@ class AlphaExtrapolation(
         n_pt = len(h_stds.axes["dijets_pt_avg"].centers)
         n_methods = len(h_stds.axes["category"].centers)  # ony length
         inter = h_stds.values()
-        inter = inter[:,:2,:,:]  # keep first two entries
+        inter = inter[:, :2, :, :]  # keep first two entries
         slope = h_stds.values()
-        slope = slope[:,:2,:,:]  # keep first two entries
+        slope = slope[:, :2, :, :]  # keep first two entries
         for m, e, p in it.product(
             range(n_methods),
             range(n_eta),
@@ -169,9 +169,9 @@ class AlphaExtrapolation(
                 "probejet_abseta": e,
                 "dijets_pt_avg": p,
             }]
-            coeff, err = self.get_correlated_fit(alphas,tmp.values(),tmp.variances())
-            inter[m,:,e,p] = [coeff[0], err[0]]
-            slope[m,:,e,p] = [coeff[1], err[1]]
+            coeff, err = self.get_correlated_fit(alphas, tmp.values(), tmp.variances())
+            inter[m, :, e, p] = [coeff[0], err[0]]
+            slope[m, :, e, p] = [coeff[1], err[1]]
 
         # NOTE: store fits into hist.
         h_intercepts = h_stds.copy()

--- a/dijet/tasks/alpha.py
+++ b/dijet/tasks/alpha.py
@@ -11,6 +11,7 @@ from columnflow.tasks.histograms import MergeHistograms
 from columnflow.util import maybe_import
 
 from dijet.tasks.base import HistogramsBaseTask
+from dijet.tasks.correlated_fit import CorrelatedFit
 
 ak = maybe_import("awkward")
 hist = maybe_import("hist")
@@ -20,7 +21,10 @@ mplhep = maybe_import("mplhep")
 it = maybe_import("itertools")
 
 
-class AlphaExtrapolation(HistogramsBaseTask):
+class AlphaExtrapolation(
+    HistogramsBaseTask,
+    CorrelatedFit,
+):
     """
     Task to perform alpha extrapolation.
     Read in and plot asymmetry histograms.
@@ -130,6 +134,9 @@ class AlphaExtrapolation(HistogramsBaseTask):
         # https://root.cern/doc/v630/TH1_8cxx_source.html#l07520
         h_stds.view().variance = h_stds.view().value**2 / (2 * np.squeeze(integral))
 
+        h_stds.view().value = np.nan_to_num(h_stds.view().value, nan=0.0)
+        h_stds.view().variance = np.nan_to_num(h_stds.view().variance, nan=0.0)
+
         # Store alphas here to get alpha up to 1
         # In the next stepts only alpha<0.3 needed; avoid slicing from there
         results_widths = {
@@ -143,32 +150,44 @@ class AlphaExtrapolation(HistogramsBaseTask):
         # exclude 0, the first bin, from alpha edges
         alphas = h_stds.axes["dijets_alpha"].edges[1:]
 
-        # TODO: Use correlated fit
-        def fit_linear(subarray):
-            fitting = ~np.isnan(subarray)
-            if len(subarray[fitting]) < 2:
-                coefficients = [0, 0]
-            else:
-                coefficients = np.polyfit(alphas[fitting], subarray[fitting], 1)
-            return coefficients
-        # TODO: save fit results (chi2, ndf, etc.) for diagnostic
-        fits = np.apply_along_axis(fit_linear, axis=axes_names.index("dijets_alpha"), arr=h_stds.view().value)
+        # TODO: More efficient procedure than for loop?
+        #       - Idea: Array with same shape but with tuple (width, error) as entry
+        n_eta = len(h_stds.axes["probejet_abseta"].centers)
+        n_pt = len(h_stds.axes["dijets_pt_avg"].centers)
+        n_methods = len(h_stds.axes["category"].centers)  # ony length
+        inter = h_stds.values()
+        inter = inter[:,:2,:,:]  # keep first two entries
+        slope = h_stds.values()
+        slope = slope[:,:2,:,:]  # keep first two entries
+        for m, e, p in it.product(
+            range(n_methods),
+            range(n_eta),
+            range(n_pt),
+        ):
+            tmp = h_stds[{
+                "category": m,
+                "probejet_abseta": e,
+                "dijets_pt_avg": p,
+            }]
+            coeff, err = self.get_correlated_fit(alphas,tmp.values(),tmp.variances())
+            inter[m,:,e,p] = [coeff[0], err[0]]
+            slope[m,:,e,p] = [coeff[1], err[1]]
 
         # NOTE: store fits into hist.
         h_intercepts = h_stds.copy()
         # Remove axis for alpha for histogram
         h_intercepts = h_intercepts[{"dijets_alpha": sum}]
         # y intercept of fit (x=0)
-        h_intercepts.view().value = fits[:, 0, :, :]
+        h_intercepts.view().value = inter[:, 0, :, :]
         # Errors temporarly used; Later get:
         # Error on fit from fit function (how?) or new method with three fits
-        h_intercepts.view().variance = np.ones(h_intercepts.shape)
+        h_intercepts.view().variance = inter[:, 1, :, :]
 
         h_slopes = h_intercepts.copy()
         # Slope of fit stored in index 1
-        h_slopes.view().value = fits[:, 1, :, :]
+        h_slopes.view().value = slope[:, 0, :, :]
         # Only stored for plotting, no defined error
-        h_slopes.view().variance = np.zeros(h_slopes.shape)
+        h_slopes.view().variance = slope[:, 1, :, :]
 
         results_extrapolation = {
             "intercepts": h_intercepts,

--- a/dijet/tasks/correlated_fit.py
+++ b/dijet/tasks/correlated_fit.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+
+import law
+from columnflow.util import maybe_import
+
+from dijet.tasks.util import chi2
+
+sc = maybe_import("scipy.optimize")
+nd = maybe_import("numdifftools")
+np = maybe_import("numpy")
+
+class CorrelatedFit():
+    """
+    Task to calculated correlated fit to widths.
+
+    ## Covariance matrix 
+    [1] Based on K. Goebel dissertation ch. A.3.
+    https://www.physik.uni-hamburg.de/en/iexp/gruppe-haller/scientific-output/documents/thesis-kristin-goebel.pdf
+
+    Example code here
+    https://github.com/UHH2/DiJetJERC/blob/ff98eebbd44931beb016c36327ab174fdf11a83f/
+    JERSF_Analysis/JER/wide_eta_binning/functions.C#L558
+    func. createCov()
+    """
+
+    def createCov(self, widths, widths_err):
+        widths_err2 = pow(widths_err, 2)  # square each element
+
+        # 3x3 matrix with the smaller error of indices i&j (Check [1])
+        # [1,2,3] ->
+        # [
+        #  [1,1,1]
+        #  [1,2,2]
+        #  [1,2,3]
+        # ]
+        matrix_err = np.maximum.outer(widths_err2,widths_err2)
+
+        ratio = ( pow(widths,2) / (2 * widths_err2) )
+        n_ratio = pow((ratio[:, None] / ratio),2)  # get ij element
+        w_ratio = (widths[:, None] / widths)  # get ij element
+
+        # Calculate the upper triangle of the covariance matrix.
+        y_cov_mc = np.triu(matrix_err * w_ratio * n_ratio)
+
+        # Fill in the lower triangle of the covariance matrix.
+        y_cov_mc += y_cov_mc.T - np.diag(y_cov_mc.diagonal())
+
+        return np.nan_to_num(y_cov_mc)
+
+    def correlated_fit(self, wmax, data, cov):
+        # Set the initial parameters.
+        params = np.array([0.05, 0.15])
+        bounds = [(0.001,0.15), (0.05,0.5)]
+
+        # Minimize the correlated fit error.
+        result = sc.minimize(
+            chi2,
+            params,
+            args=(wmax, data, cov)
+        )
+
+        hess = nd.Hessian(chi2)(result.x, wmax, data, cov)
+        hess_inv = np.linalg.inv(hess)
+
+        pcov = 2.0 * hess_inv
+        perr = np.sqrt(np.diag(pcov))
+
+        return result.x, perr
+
+    def get_correlated_fit(self, wmax, std, err):
+        # In case of very few events in a eta-pt bin two alpha bins can be equal
+        # In that case the matrix is not invertable "numpy.linalg.LinAlgError: Singular matrix"
+        # np.insert(std[:-1] != std[1:], 0, True) sets entry i to False if entry i-1 is equal
+        mask = (
+            (std != 0) &
+            np.insert(std[:-1] != std[1:], 0, True)
+        )
+        if len(mask[mask]) < 2:
+                return [[0,0], [0,0]]
+
+        wmax = wmax[mask]
+        std = std[mask]
+        err = err[mask]
+
+        y_cov_mc = self.createCov(widths=std, widths_err=err)
+        y_cov_mc_inv = np.linalg.inv(y_cov_mc)
+        popt, perr = self.correlated_fit(wmax, std, y_cov_mc_inv)
+
+        return popt, perr

--- a/dijet/tasks/correlated_fit.py
+++ b/dijet/tasks/correlated_fit.py
@@ -33,7 +33,7 @@ class CorrelatedFit():
         #  [1,2,2]
         #  [1,2,3]
         # ]
-        matrix_err = np.maximum.outer(widths_err2, widths_err2)
+        matrix_err = np.minimum.outer(widths_err2, widths_err2)
 
         ratio = widths**2 / (2 * widths_err2)
         n_ratio = (ratio[:, None] / ratio)**2  # get ij element

--- a/dijet/tasks/correlated_fit.py
+++ b/dijet/tasks/correlated_fit.py
@@ -1,19 +1,19 @@
 # coding: utf-8
 
-import law
 from columnflow.util import maybe_import
 
-from dijet.tasks.util import chi2
+from dijet.tasks.util import chi2_linear
 
 sc = maybe_import("scipy.optimize")
 nd = maybe_import("numdifftools")
 np = maybe_import("numpy")
 
+
 class CorrelatedFit():
     """
     Task to calculated correlated fit to widths.
 
-    ## Covariance matrix 
+    ## Covariance matrix
     [1] Based on K. Goebel dissertation ch. A.3.
     https://www.physik.uni-hamburg.de/en/iexp/gruppe-haller/scientific-output/documents/thesis-kristin-goebel.pdf
 
@@ -23,8 +23,8 @@ class CorrelatedFit():
     func. createCov()
     """
 
-    def createCov(self, widths, widths_err):
-        widths_err2 = pow(widths_err, 2)  # square each element
+    def create_cov(self, widths, widths_err):
+        widths_err2 = widths_err**2  # square each element
 
         # 3x3 matrix with the smaller error of indices i&j (Check [1])
         # [1,2,3] ->
@@ -33,13 +33,13 @@ class CorrelatedFit():
         #  [1,2,2]
         #  [1,2,3]
         # ]
-        matrix_err = np.maximum.outer(widths_err2,widths_err2)
+        matrix_err = np.maximum.outer(widths_err2, widths_err2)
 
-        ratio = ( pow(widths,2) / (2 * widths_err2) )
-        n_ratio = pow((ratio[:, None] / ratio),2)  # get ij element
+        ratio = widths**2 / (2 * widths_err2)
+        n_ratio = (ratio[:, None] / ratio)**2  # get ij element
         w_ratio = (widths[:, None] / widths)  # get ij element
 
-        # Calculate the upper triangle of the covariance matrix.
+        # Consider only the upper triangle of the covariance matrix.
         y_cov_mc = np.triu(matrix_err * w_ratio * n_ratio)
 
         # Fill in the lower triangle of the covariance matrix.
@@ -47,19 +47,19 @@ class CorrelatedFit():
 
         return np.nan_to_num(y_cov_mc)
 
-    def correlated_fit(self, wmax, data, cov):
+    @staticmethod
+    def correlated_fit(wmax, data, cov_inv):
         # Set the initial parameters.
         params = np.array([0.05, 0.15])
-        bounds = [(0.001,0.15), (0.05,0.5)]
 
         # Minimize the correlated fit error.
         result = sc.minimize(
-            chi2,
+            chi2_linear,
             params,
-            args=(wmax, data, cov)
+            args=(wmax, data, cov_inv),
         )
 
-        hess = nd.Hessian(chi2)(result.x, wmax, data, cov)
+        hess = nd.Hessian(chi2_linear)(result.x, wmax, data, cov_inv)
         hess_inv = np.linalg.inv(hess)
 
         pcov = 2.0 * hess_inv
@@ -76,13 +76,13 @@ class CorrelatedFit():
             np.insert(std[:-1] != std[1:], 0, True)
         )
         if len(mask[mask]) < 2:
-                return [[0,0], [0,0]]
+            return [[0, 0], [0, 0]]
 
         wmax = wmax[mask]
         std = std[mask]
         err = err[mask]
 
-        y_cov_mc = self.createCov(widths=std, widths_err=err)
+        y_cov_mc = self.create_cov(widths=std, widths_err=err)
         y_cov_mc_inv = np.linalg.inv(y_cov_mc)
         popt, perr = self.correlated_fit(wmax, std, y_cov_mc_inv)
 

--- a/dijet/tasks/jer.py
+++ b/dijet/tasks/jer.py
@@ -47,7 +47,22 @@ class JER(HistogramsBaseTask):
         return reqs
 
     def load_extrapolation(self):
-        histogram = self.input().collection[0]["extrapolation"].load(formatter="pickle")
+        # TODO: This task loads both, data [0] and MC [1], at the same time.
+        #       Decide which collection to take, but think about solution to run
+        #       self.input()[sample]["collection"][0]
+        sample = self.extract_sample()
+        dir0 = self.input().collection[0]["widths"].path
+        dir1 = self.input().collection[1]["widths"].path
+        if sample in dir0:
+            ind = 0
+        elif sample in dir1:
+            ind = 1
+        else:
+            raise RuntimeError(
+                f"Sample {sample} does not match input paths:\n"
+                f"{dir0}\n{dir1}",
+            )
+        histogram = self.input().collection[ind]["extrapolation"].load(formatter="pickle")
         return histogram
 
     def output(self) -> dict[law.FileSystemTarget]:

--- a/dijet/tasks/jer.py
+++ b/dijet/tasks/jer.py
@@ -37,8 +37,6 @@ class JER(HistogramsBaseTask):
     def requires(self):
         return self.reqs.AlphaExtrapolation.req(
             self,
-            branch=-1,
-            _exclude={"branches"},
         )
 
     def workflow_requires(self):
@@ -47,22 +45,7 @@ class JER(HistogramsBaseTask):
         return reqs
 
     def load_extrapolation(self):
-        # TODO: This task loads both, data [0] and MC [1], at the same time.
-        #       Decide which collection to take, but think about solution to run
-        #       self.input()[sample]["collection"][0]
-        sample = self.extract_sample()
-        dir0 = self.input().collection[0]["widths"].path
-        dir1 = self.input().collection[1]["widths"].path
-        if sample in dir0:
-            ind = 0
-        elif sample in dir1:
-            ind = 1
-        else:
-            raise RuntimeError(
-                f"Sample {sample} does not match input paths:\n"
-                f"{dir0}\n{dir1}",
-            )
-        histogram = self.input().collection[ind]["extrapolation"].load(formatter="pickle")
+        histogram = self.input()["extrapolation"].load(formatter="pickle")
         return histogram
 
     def output(self) -> dict[law.FileSystemTarget]:
@@ -76,6 +59,7 @@ class JER(HistogramsBaseTask):
 
     def run(self):
         # load extrapolation results
+        # from IPython import embed;embed()
         results_extrapolation = self.load_extrapolation()
 
         # get extrapolated distribution widths

--- a/dijet/tasks/jer.py
+++ b/dijet/tasks/jer.py
@@ -59,7 +59,6 @@ class JER(HistogramsBaseTask):
 
     def run(self):
         # load extrapolation results
-        # from IPython import embed;embed()
         results_extrapolation = self.load_extrapolation()
 
         # get extrapolated distribution widths

--- a/dijet/tasks/util.py
+++ b/dijet/tasks/util.py
@@ -1,10 +1,17 @@
 # coding: utf-8
 
 def linear_function(x, p):
+    """Linear function in `x` with slope `p[0]` and intercept `p[1]`."""
     return p[0] * x + p[1]
 
-def chi2(p, x, data, cov):
+
+def chi2_linear(p, x, data, cov_inv):
+    """
+    Chi2 function to minimize assuming the model follows a linear function
+    of `x` with parameters `p`, compared to `data` with inverse covariance
+    matrix `cov_inv`.
+    """
     y_hat = linear_function(x=x, p=p)
     residuals = data - y_hat
-    chi2 = residuals.T @ cov @ residuals
+    chi2 = residuals.T @ cov_inv @ residuals
     return chi2

--- a/dijet/tasks/util.py
+++ b/dijet/tasks/util.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+
+def linear_function(x, p):
+    return p[0] * x + p[1]
+
+def chi2(p, x, data, cov):
+    y_hat = linear_function(x=x, p=p)
+    residuals = data - y_hat
+    chi2 = residuals.T @ cov @ residuals
+    return chi2


### PR DESCRIPTION
In an earlier PR I moved `branch=-1` to `_exclude={"branches"}` for the plotting tasks Alpha and Asymmetry.
In both cases I use a `branch map`, which was not recognized afterwards.
This PR reverts the changes, now working again for all branches and also taking `data` and `MC` as input simultaneously.