### PR TITLE
set branch in requirement

### DIFF
--- a/dijet/plotting/alpha.py
+++ b/dijet/plotting/alpha.py
@@ -56,7 +56,7 @@ class PlotWidth(
         return self.reqs.AlphaExtrapolation.req(
             self,
             processes=("qcd", "data"),
-            _exclude={"branches"},
+            branch=-1,
         )
 
     def load_widths(self):

--- a/dijet/plotting/asymmetry.py
+++ b/dijet/plotting/asymmetry.py
@@ -51,7 +51,7 @@ class PlotAsymmetries(
         return self.reqs.AlphaExtrapolation.req(
             self,
             processes=("qcd", "data"),
-            _exclude={"branches"},
+            branch=-1,
         )
 
     def load_asymmetry(self):


### PR DESCRIPTION
In an earlier PR I moved `branch=-1` to `_exclude={"branches"}` for the plotting tasks Alpha and Asymmetry.
In both cases I use a `branch map`, which was not recognized afterwards.
This PR reverts the changes, now working again for all branches and also taking `data` and `MC` as input simultaneously.