### PR TITLE
Bug hunt

### DIFF
--- a/dijet/plotting/alpha.py
+++ b/dijet/plotting/alpha.py
@@ -187,7 +187,7 @@ class PlotWidth(
                 )
                 # adjust for gen-level
                 if level == "gen":
-                    plot_kwargs.update({
+                    plot_kwargs = dict(plot_kwargs, **{
                         "color": "forestgreen",
                         "label": "MC (gen)",
                         "marker": "d",

--- a/dijet/plotting/asymmetry.py
+++ b/dijet/plotting/asymmetry.py
@@ -189,7 +189,7 @@ class PlotAsymmetries(
                 )
                 # adjust for gen-level
                 if level == "gen":
-                    plot_kwargs.update({
+                    plot_kwargs = dict(plots_kwargs, **{
                         "color": "forestgreen",
                         "label": "MC (gen)",
                         "method": "step",

--- a/dijet/tasks/alpha.py
+++ b/dijet/tasks/alpha.py
@@ -100,7 +100,7 @@ class AlphaExtrapolation(
         # start main processing
         #
 
-        h_asyms = self.load_input("asym", level=level)
+        h_asyms = self.load_input("asym_cut", level=level)
         h_nevts = self.load_input("nevt", level=level)
 
         # Get widths of asymmetries

--- a/dijet/tasks/asymmetry.py
+++ b/dijet/tasks/asymmetry.py
@@ -231,8 +231,8 @@ class Asymmetry(
         mask = (asym_centers_reshaped > asym_edges_lo) & (asym_centers_reshaped < asym_edges_up)
 
         # Filter non gaussian tailes
-        view.value = np.where(mask, view.value, np.nan)
-        view.variance = np.where(mask, view.variance, np.nan)
+        view.value = np.where(mask, view.value, 0)
+        view.variance = np.where(mask, view.variance, 0)
 
         # Store in pickle file for plotting task
         self.dump_output("asym_cut", level=level, obj=h_all)


### PR DESCRIPTION
Fixed the following bugs in the dijets cf analysis:

1. The issue that histograms with MC reco and gen information used the same color and legend
2. The issue that for the width histograms the uncut version where used
3. That the cutting procedure sets the cut regions to nan instead of zero. This would render all later calculations of e.g. mean and std to nan as well.